### PR TITLE
Python 3 support

### DIFF
--- a/pyzem/compute/bodysplit.py
+++ b/pyzem/compute/bodysplit.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import subprocess
 
 from pyzem.dvid import dvidenv
@@ -14,13 +15,13 @@ class BodySplit:
         self._server = server
 
     def run(self, task_key):
-        print self._neutu
+        print(self._neutu)
         du = dvidenv.DvidUrl(self._server)
         task_url = du.get_url(du.get_split_task_path(task_key)) 
-        print task_url
+        print(task_url)
 
         args = [self._neutu, '--command', '--general', '{"command": "split_body"}', task_url, '-o', du.get_node_url()]
-        print args
+        print(args)
         p = subprocess.Popen(args)
         p.wait()
         return p

--- a/pyzem/dvid/dvidenv.py
+++ b/pyzem/dvid/dvidenv.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import json
-import urlparse
+import urllib.parse
 
 REF_KEY = '->'
 
@@ -27,7 +27,7 @@ class DvidUrl(object):
         return self._env._port
 
     def join(self, *args):
-        newargs = map(lambda x: str(x).rstrip('/').lstrip('/'), args)
+        newargs = [str(x).rstrip('/').lstrip('/') for x in args]
         #newargs = map(lambda x: '/' + x if (x[0] != '/') else x, newargs)
         #print newargs
         

--- a/pyzem/dvid/dvidenv.py
+++ b/pyzem/dvid/dvidenv.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 import urlparse
 
@@ -150,16 +151,16 @@ class DvidEnv(object):
 
 if __name__ == "__main__":
     du = DvidUrl(DvidEnv(host = "emdata1.int.janelia.org", port = 8700, uuid = "4320", labelvol = "pb26-27-2-trm-eroded32_ffn-20170216-2_celis_cx2-2048_r10_0_seeded_64blksz_vol"))
-    print du.join('test', 'key')
-    print du.get_url('test', 'key')
-    print du.get_split_seed_url('keys')
-    print du.get_node_path()
-    print du.get_node_url()
-    print du.get_keys_path('test')
-    print du.get_keyvalue_path('test', 'key1')
-    print du.get_split_task_path()
-    print du.join(du.get_split_task_path(), 'keys')
-    print du.get_split_task_property_path()
-    print du.get_split_result_property_path('test')
-    print du.get_split_task_property_path('test')
-    print du.get_split_result_property_path()
+    print(du.join('test', 'key'))
+    print(du.get_url('test', 'key'))
+    print(du.get_split_seed_url('keys'))
+    print(du.get_node_path())
+    print(du.get_node_url())
+    print(du.get_keys_path('test'))
+    print(du.get_keyvalue_path('test', 'key1'))
+    print(du.get_split_task_path())
+    print(du.join(du.get_split_task_path(), 'keys'))
+    print(du.get_split_task_property_path())
+    print(du.get_split_result_property_path('test'))
+    print(du.get_split_task_property_path('test'))
+    print(du.get_split_result_property_path())

--- a/pyzem/dvid/dvidenv.py
+++ b/pyzem/dvid/dvidenv.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 import json
-import urllib.parse
 
 REF_KEY = '->'
 

--- a/pyzem/dvid/dvidio.py
+++ b/pyzem/dvid/dvidio.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import sys
 
 from optparse import OptionParser
 import json
 import requests
-import dvidenv
+from . import dvidenv
 import datetime
 
 class DvidClient:
@@ -20,17 +22,17 @@ class DvidClient:
 
     def print_split_result(self):
         url = self._url.join(self._url.get_split_result_url(), 'keyrange', 'task__0/task__z')
-        print url
+        print(url)
         r = requests.get(self._url.join(self._url.get_split_result_url(), 'keyrange', 'task__0/task__z'))
-        print r.text
+        print(r.text)
 
         resultList = json.loads(r.text)
         for result in resultList:
             r = requests.get(self._url.join(self._url.get_split_result_url(), 'key', result))
             resultJson = json.loads(r.text)
-            print resultJson[dvidenv.REF_KEY]
+            print(resultJson[dvidenv.REF_KEY])
             r = requests.get(self._url.join(self._url.get_node_url(), resultJson[dvidenv.REF_KEY]))
-            print r.text
+            print(r.text)
             
     def clear_split_task(self):
         keys = self.read_keys(path = self._url.get_split_task_path())
@@ -39,8 +41,8 @@ class DvidClient:
             try:
                 r = requests.delete(url)
             except Exception as e:
-                print "request failed"
-                print url 
+                print("request failed")
+                print(url) 
 
     def clear_split_result(self):
         keys = self.read_keys(path = self._url.get_split_result_path())
@@ -49,8 +51,8 @@ class DvidClient:
             try:
                 r = requests.delete(url)
             except Exception as e:
-                print "request failed"
-                print url 
+                print("request failed")
+                print(url) 
 
     def read_split_task_keys(self):
         return self.read_keys(path = self._url.get_split_task_path(), range = ['task__0', 'task__z'])
@@ -72,15 +74,15 @@ class DvidClient:
         for task in taskList:
             r = requests.get(self._url.get_url(self._url.get_split_task_path(), 'key', task))
             taskJson = json.loads(r.text)
-            if taskJson.has_key('->'):
+            if '->' in taskJson:
 #                 print taskJson['->']
                 data = self.read_path(taskJson['->'])
 #                 print data
                 taskJson = json.loads(data)
-            print task
-            print '  signal:', taskJson.get('signal')
-            print '  #seeds:', len(taskJson.get('seeds'))
-            print '  Age:', self.read_split_task_age(task)
+            print(task)
+            print('  signal:', taskJson.get('signal'))
+            print('  #seeds:', len(taskJson.get('seeds')))
+            print('  Age:', self.read_split_task_age(task))
     
     def decode_response(self, r):
         return json.loads(r.text)
@@ -90,15 +92,15 @@ class DvidClient:
         return r.text
 
     def read_keys(self, path = None, keyvalue = None, range = None):
-        print keyvalue
+        print(keyvalue)
         if keyvalue:
             path = self._url.get_data_path(keyvalue)
             
-        print path
+        print(path)
         if path:
             if not range:
                 url = self._url.get_url(path, 'keys')
-                print url
+                print(url)
                 return self.decode_response(requests.get(url))
             else:
                 return self.decode_response(requests.get(self._url.join(self._url.get_url(path, 'keyrange', range[0], range[1]))))
@@ -114,7 +116,7 @@ class DvidClient:
             if r.status_code == 200:
                 return r.text
         except:
-            print 'No', key
+            print('No', key)
             pass
         
         return None
@@ -149,7 +151,7 @@ class DvidClient:
         text = self.read_key(keyvalue = dvidenv.get_split_task_property(), key = key)
         try:
             d = json.loads(text)
-            if d.has_key('timestamp'):
+            if 'timestamp' in d:
                 return datetime.datetime.strptime(d['timestamp'], '%Y-%m-%d %H:%M:%S.%f')
         except Exception as e:
             pass
@@ -158,7 +160,7 @@ class DvidClient:
 
     def read_split_result_time_stamp(self, key):
         d = json.loads(self.read_key(keyvalue = dvidenv.get_split_result_property(), key = key))
-        if d.has_key('timestamp'):
+        if 'timestamp' in d:
             return datetime.datetime.strptime(d['timestamp'], '%Y-%m-%d %H:%M:%S.%f')
         return None
 
@@ -181,7 +183,7 @@ class DvidClient:
     def update_ref_set(self, data = None, key = None, result = None):
         if result is not None:
             keyJson = json.loads(self.read_key(keyvalue = data, key = key))
-            if keyJson and keyJson.has_key(dvidenv.REF_KEY):
+            if keyJson and dvidenv.REF_KEY in keyJson:
                 ref = keyJson[dvidenv.REF_KEY]
                 refKey = ref.split('/')[-1]
                 result.add(refKey)
@@ -216,9 +218,9 @@ if __name__ == '__main__':
     #print r.status
     #print r.msg
     keys = dvid.read_split_task_keys()
-    print keys
+    print(keys)
     for key in keys:
-        print dvid.has_key(key = key, keyvalue = dvidenv.get_split_result())
+        print(dvid.has_key(key = key, keyvalue = dvidenv.get_split_result()))
 #     dvid.print_split_task()/
 #     dvid.print_split_result()
     #dvid.clear_split_task()

--- a/pyzem/studio/MovieScriptWriter.py
+++ b/pyzem/studio/MovieScriptWriter.py
@@ -14,7 +14,7 @@ class MovieScene:
     def addAction(self, scene, actorId, action):
         if "action" not in self.scene:
             self.scene["action"] = list();
-        self.scene["action"].append(dict({"id": actorId}.items() + action.items()));        
+        self.scene["action"].append(dict(list({"id": actorId}.items()) + list(action.items())));        
         
 class MovieScriptWriter:
     '''

--- a/pyzem/studio/movie.py
+++ b/pyzem/studio/movie.py
@@ -17,7 +17,7 @@ def addActor(cast, actorId, actorSource):
 def addAction(scene, actorId, action):
     if "action" not in scene:
         scene["action"] = list();
-    scene["action"].append(dict({"id": actorId}.items() + action.items()));
+    scene["action"].append(dict(list({"id": actorId}.items()) + list(action.items())));
 
 if __name__ == '__main__':
     movieScript = {};

--- a/pyzem/studio/movie.py
+++ b/pyzem/studio/movie.py
@@ -3,6 +3,7 @@ Created on Jun 12, 2013
 
 @author: zhaot
 '''
+from __future__ import print_function
 
 def pauseScene(duration):
     return {"duration": duration};
@@ -25,5 +26,5 @@ if __name__ == '__main__':
     addActor(movieScript["cast"], "test2", "test2.swc");
     scene = newScene(1000);
     addAction(scene, "test", {"color": [1, 0, 0], "move": [0, 0, 1]});
-    print movieScript;
-    print scene;
+    print(movieScript);
+    print(scene);

--- a/pyzem/studio/moviehelper.py
+++ b/pyzem/studio/moviehelper.py
@@ -3,12 +3,14 @@ Created on Apr 11, 2016
 
 @author: zhaot
 '''
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
 
-import MovieScriptWriter as mw
-import movie
+from . import MovieScriptWriter as mw
+from . import movie
 
 class MovieHelper(object):
     '''
@@ -31,15 +33,15 @@ class MovieHelper(object):
             for neuronId in self.neuronNameIdMap[name]:
                 filePath = self.castDir + "/" + neuronId + ".swc"
                 if not os.path.isfile(filePath):
-                    print "WARNING: no file for", name, "(" + neuronId + ")", "-", filePath
+                    print("WARNING: no file for", name, "(" + neuronId + ")", "-", filePath)
                 else:
-                    print name, "added"
+                    print(name, "added")
                     actorList.append(neuronId)
                     self.scriptWriter.addActor(neuronId, filePath)
                     
                 filePath = self.castDir + "/" + neuronId + ".marker"
                 if os.path.isfile(filePath):
-                    print name, "added"
+                    print(name, "added")
                     markerId = neuronId + "_marker"
                     actorList.append(markerId)
                     self.scriptWriter.addActor(markerId, filePath)

--- a/pyzem/test.py
+++ b/pyzem/test.py
@@ -1,18 +1,20 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import timer
 import threading
 import time
 
-from dvid import dvidenv
-from dvid import dvidio
-from compute import bodysplit
+from .dvid import dvidenv
+from .dvid import dvidio
+from .compute import bodysplit
 
 split = bodysplit.BodySplit('/Users/zhaot/Work/neutube/neurolabi/neuTube_Debug_FlyEM/neutu_d.app/Contents/MacOS/neutu_d', dvidenv.DvidEnv(host = 'localhost', port=8000, uuid='4d3e'))
-print split._neutu
+print(split._neutu)
 #split.run('task__http-++emdata1.int.janelia.org-8500+api+node+b6bc+bodies+sparsevol+12007338')
 
 dc = dvidio.DvidClient(host = 'localhost', port=8000, uuid='4d3e')
 splitTaskList = dc.read_split_task_keys()
-print splitTaskList
+print(splitTaskList)
 
 #dc.clear_split_task()
 #dc.clear_split_result()
@@ -21,7 +23,7 @@ print splitTaskList
 def process():
     while True:
         splitTaskList = dc.read_split_task_keys()
-        print splitTaskList
+        print(splitTaskList)
         for task in splitTaskList:
             split.run(task)
         time.sleep(10)


### PR DESCRIPTION
Adds support for Python 3 without dropping support for Python 2.

The only changes necessary were: 

- Convert `print` statements to `print()` function calls
- Use relative import syntax where necessary (e.g. `from . import dvidenv`)
- Don't use `dict.has_key()`
- Wrap `dict.items()` with `list()`, since it returns an iterator in Python 3.
- Removed `import urlparse`, since it has been renamed in python 3 and it wasn't used in your code anyway.